### PR TITLE
Deletes invite links if no 'Server Staff' role.

### DIFF
--- a/Commando.js
+++ b/Commando.js
@@ -59,7 +59,7 @@ client.on('error', winston.error)
 	.on('message', async (message) => {
 		if (message.channel.type === 'dm') return;
 
-		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && /https:\/\/discord\.gg\/\w{+}/.test(message.content)) {
+		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && /https:\/\/discord\.gg\/\w+/.test(message.content)) {
 			message.delete();
 			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.');
 		}

--- a/Commando.js
+++ b/Commando.js
@@ -59,6 +59,10 @@ client.on('error', winston.error)
 	.on('message', async (message) => {
 		if (message.channel.type === 'dm') return;
 
+		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && message.content.includes('discord.gg')) {
+			message.delete();
+			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.')
+		}
 		const channelLocks = client.provider.get(message.guild.id, 'locks', []);
 		if (channelLocks.includes(message.channel.id)) return;
 		if (message.author.bot) return;

--- a/Commando.js
+++ b/Commando.js
@@ -59,7 +59,7 @@ client.on('error', winston.error)
 	.on('message', async (message) => {
 		if (message.channel.type === 'dm') return;
 
-		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && /https:\/\/discord\.gg\/\w{5}/.test(message.content)) {
+		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && /https:\/\/discord\.gg\/\w{+}/.test(message.content)) {
 			message.delete();
 			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.');
 		}

--- a/Commando.js
+++ b/Commando.js
@@ -61,7 +61,7 @@ client.on('error', winston.error)
 
 		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && message.content.includes('discord.gg')) {
 			message.delete();
-			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.')
+			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.');
 		}
 		const channelLocks = client.provider.get(message.guild.id, 'locks', []);
 		if (channelLocks.includes(message.channel.id)) return;

--- a/Commando.js
+++ b/Commando.js
@@ -22,7 +22,6 @@ const client = new commando.Client({
 	unknownCommandResponse: false,
 	disableEveryone: true
 });
-const invitePattern = new RegExp('/https:\/\/discord\.gg\/\w{5}/');
 
 let earnedRecently = [];
 let gainedXPRecently = [];
@@ -60,7 +59,7 @@ client.on('error', winston.error)
 	.on('message', async (message) => {
 		if (message.channel.type === 'dm') return;
 
-		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && invitePattern.test(message.content)) {
+		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && /https:\/\/discord\.gg\/\w{5}/.test(message.content)) {
 			message.delete();
 			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.');
 		}

--- a/Commando.js
+++ b/Commando.js
@@ -22,6 +22,7 @@ const client = new commando.Client({
 	unknownCommandResponse: false,
 	disableEveryone: true
 });
+const invitePattern = new RegExp('/https:\/\/discord\.gg\/\w{5}/');
 
 let earnedRecently = [];
 let gainedXPRecently = [];
@@ -59,7 +60,7 @@ client.on('error', winston.error)
 	.on('message', async (message) => {
 		if (message.channel.type === 'dm') return;
 
-		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && message.content.includes('discord.gg')) {
+		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && invitePattern.test(message.content)) {
 			message.delete();
 			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.');
 		}


### PR DESCRIPTION
People keep complaining that invite links are posted in d.js
So commando can now delete them and warn them not to post invite links. 👌 

Note: users with the Sever Staff role can bypass it.