### PR TITLE
Discord invite links will be deleted

### DIFF
--- a/Commando.js
+++ b/Commando.js
@@ -59,6 +59,10 @@ client.on('error', winston.error)
 	.on('message', async (message) => {
 		if (message.channel.type === 'dm') return;
 
+		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && /https:\/\/discord\.gg\/\w+/.test(message.content)) {
+  			message.delete();
+  			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.');
+  		}
 		const channelLocks = client.provider.get(message.guild.id, 'locks', []);
 		if (channelLocks.includes(message.channel.id)) return;
 		if (message.author.bot) return;

--- a/Commando.js
+++ b/Commando.js
@@ -60,9 +60,9 @@ client.on('error', winston.error)
 		if (message.channel.type === 'dm') return;
 
 		if (message.guild.id === '222078108977594368' && !message.member.roles.has('242700009961816065') && /https:\/\/discord\.gg\/\w+/.test(message.content)) {
-  			message.delete();
-  			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.');
-  		}
+			message.delete();
+			message.reply('Please do not post invite links on this server. If you wish to give invite links, do so in direct messages.');
+		}
 		const channelLocks = client.provider.get(message.guild.id, 'locks', []);
 		if (channelLocks.includes(message.channel.id)) return;
 		if (message.author.bot) return;


### PR DESCRIPTION
Deletes discord invite links inside the d.js guild and prompts the user to not post them.
Note: users with the Server Staff role can bypass this.