### PR TITLE
Make tag usage without ?tag case-insensitive

### DIFF
--- a/Commando.js
+++ b/Commando.js
@@ -117,7 +117,7 @@ client.on('error', winston.error)
 		if (msg.channel.type === 'dm') return;
 		if (msg.author.bot) return;
 
-		const args = { name: msg.content.split(client.commandPrefix)[1] };
+		const args = { name: msg.content.split(client.commandPrefix)[1].toLowerCase() };
 		client.registry.resolveCommand('tags:tag').run(msg, args);
 	})
 	.on('commandError', (cmd, err) => {


### PR DESCRIPTION
The tags are converted to lower case when they are added. So by adding `.toLowerCase()`, we can eliminate the case difference and tags that contain upper case letters such as "?isCommand" can trigger the tag.
Edit: Note that "?tag isCommand" already does that. I just found it inconsistent.